### PR TITLE
chore: update changelog for publicNetworkAccess documentation

### DIFF
--- a/avm/res/document-db/mongo-cluster/CHANGELOG.md
+++ b/avm/res/document-db/mongo-cluster/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 The latest version of the changelog can be found [here](https://github.com/Azure/bicep-registry-modules/blob/main/avm/res/document-db/mongo-cluster/CHANGELOG.md).
 
+## 0.4.3
+
+### Changes
+
+- Add documentation for the new `publicNetworkAccess` parameter, describing its usage and allowed values in the README.
+
+### Breaking Changes
+
+- None
+
+## 0.4.2
+
+### Changes
+
+- Add `publicNetworkAccess` parameter to enable or disable public network access.
+
+### Breaking Changes
+
+- None
+
 ## 0.4.2
 
 ### Changes


### PR DESCRIPTION
Update changelog to reflect documentation changes for the publicNetworkAccess parameter in the mongo-cluster module.